### PR TITLE
fix: spawn main thread onto runtime

### DIFF
--- a/tokio-ping-tcp/src/main.rs
+++ b/tokio-ping-tcp/src/main.rs
@@ -95,11 +95,11 @@ async fn run(
                 // framework, transport, test, count, rate, payload, tasks, value, unit
                 println!(
                     "tokio,tcp,rtt,{},{},{},{},{},ns",
-                count,
-                interval,
-                payload.len(),
-                tasks,
-                instant.elapsed().as_nanos()
+                    count,
+                    interval,
+                    payload.len(),
+                    tasks,
+                    instant.elapsed().as_nanos()
                 );
             } else {
                 println!(
@@ -131,7 +131,7 @@ fn main() {
     let args = Args::parse();
 
     let rt = Runtime::new().unwrap();
-    rt.block_on(async {
+    let handle = rt.spawn(async move {
         for _ in 0..args.spawn {
             tokio::spawn(async move {
                 let mut x: usize = 1;
@@ -151,4 +151,5 @@ fn main() {
             .await
             .unwrap();
     });
+    rt.block_on(handle).unwrap();
 }

--- a/tokio-ping-udp/src/main.rs
+++ b/tokio-ping-udp/src/main.rs
@@ -109,11 +109,11 @@ async fn run(
                 // framework, transport, test, count, rate, payload, tasks, value, unit
                 println!(
                     "tokio,udp,rtt,{},{},{},{},{},ns",
-                count,
-                interval,
-                payload.len(),
-                tasks,
-                instant.elapsed().as_nanos()
+                    count,
+                    interval,
+                    payload.len(),
+                    tasks,
+                    instant.elapsed().as_nanos()
                 );
             } else {
                 println!(
@@ -145,7 +145,7 @@ fn main() {
     let args = Args::parse();
 
     let rt = Runtime::new().unwrap();
-    rt.block_on(async {
+    let handle = rt.spawn(async move {
         for _ in 0..args.spawn {
             tokio::spawn(async move {
                 let mut x: usize = 1;
@@ -179,4 +179,5 @@ fn main() {
         .await
         .unwrap();
     });
+    rt.block_on(handle).unwrap();
 }


### PR DESCRIPTION
The Tokio runtime `block_on` function will run the given future on the _current_ thread, while the spawned tasks will end up within the executor. To better benefit from the fact that there is a lot of communication work happening in the top-level task, it should instead be spawned onto the executor where work-stealing may have a visible improvement. Otherwise, any communication between the top-level task and its children _requires_ a context switch may significantly impact performance.

I tried to run this locally, but I have a macOS, so your shell scripts wouldn't work for me without needing to dig in and figure a lot more out.

Nonetheless, you should retry your latency tests with this change and see if this improves things.

The tokio team may be making some changes in the future to remove this rough edge.